### PR TITLE
Changed folder structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,11 @@ secrets.env
 # IDEs
 .vscode
 .idea
+
+# Images to be resized
+images_original/*
+!images_original/.gitkeep
+
+# Images already resized
+images_resized/*
+!images_resized/.gitkeep

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-# Image resize on the fly AWS Lambda function with Serverless and Node.js
+> Image resize on-the-fly using AWS Lambda function with Serverless and Node.js
 
 A simple Serverless service for creating an image resize-on-the-fly function with AWS Lambda. For Sharp to work correctly it must be installed in the same environment the production is running in. Because AWS Lambda is running on Amazon Linux it must be installed on the same system.
 
@@ -18,19 +18,19 @@ This service will deploy both the AWS Lambda function and AWS S3 bucket from whe
 
 These instructions will get you up and running. See deployment for notes on how to deploy the project on a live system.
 
-#### Clone to your local machine:
+#### Clone to your local machine
 
 ```bash
-$ git clone https://github.com/ferdn4ndo/userver-serverless-image-resize.git
+git clone https://github.com/ferdn4ndo/userver-serverless-image-resize.git
 ```
 
-#### Change into the cloned dir:
+#### Change into the cloned dir
 
 ```bash
-$ cd userver-serverless-image-resize
+cd userver-serverless-image-resize
 ```
 
-#### Install Docker and docker compose:
+#### Install Docker and docker compose
 
 Please follow the instructions available at [Install Docker Engine on Ubuntu](https://docs.docker.com/engine/install/ubuntu/).
 
@@ -47,6 +47,7 @@ The `deploy.sh` script will autogenerate this file. No need to touch it at all.
 #### 2. `secrets.env`
 
 Add your secret keys and configuration variables here.
+
 ```env
 SLS_KEY=XXX
 SLS_SECRET=YYY
@@ -58,7 +59,7 @@ BUCKET=images.your-domain.com
 ### Run Docker Compose
 
 ```bash
-$ docker compose up --build
+docker compose up --build
 ```
 
 This will build the image, create a container, run the `deploy.sh` script inside the container and deploy all the resources.
@@ -67,26 +68,44 @@ The command line will log out the service endpoints and all info. What's importa
 
 ## Usage
 
-After the service has been deployed, you will receive a bucket endpoint. You will add a query parameter to it tell it how to resize the image. The bucket will behave as a public website.
+After the service has been deployed, you will receive a bucket endpoint. You will add a query parameter to tell it how to resize the image. The bucket will behave as a public website.
 
-Let's upload an image so we have something to work with.
+Let's upload an image so we have something to work with. The original images (yet to be resized) should be uploaded to the `images_original` subfolder.
+
 ```bash
-$ aws s3 cp --acl public-read IMAGE_NAME.jpg s3://BUCKET
+aws s3 cp --acl public-read IMAGE_NAME.jpg s3://<BUCKET>/images_original
 ```
 
-Example 1:
+Then you will execute the lambda function to resize it. In this example. we will resize the `IMAGE_NAME.jpg` file to 1080 (width) x 720 (height) pixels.
+
 ```
-http://BUCKET.s3-website.REGION.amazonaws.com/420x360/IMAGE_NAME.jpg
+https://<LAMBDA_ID>.execute-api.<REGION>.amazonaws.com/prod/resize?key=1080x720/IMAGE_NAME.jpg
 ```
+
+**NOTE**: The `LAMBDA_ID` parameter is printed when the container is deploying the function. Consider this example:
+
+```
+userver-serverless-image-resize-deploy  | Deploying userver-serverless-image-resize-fn to stage prod (us-east-1)
+userver-serverless-image-resize-deploy  | Tracing DISABLED for function "userver-serverless-image-resize-fn-prod-resize"
+userver-serverless-image-resize-deploy  |
+userver-serverless-image-resize-deploy  | ✔ Service deployed to stack userver-serverless-image-resize-fn-prod (55s)
+userver-serverless-image-resize-deploy  |
+userver-serverless-image-resize-deploy  | endpoint: GET - https://12345abcde.execute-api.us-east-1.amazonaws.com/prod/resize
+userver-serverless-image-resize-deploy  | functions:
+userver-serverless-image-resize-deploy  |   resize: userver-serverless-image-resize-fn-prod-resize (9 MB)
+```
+
+In this case, the `LAMBDA_ID` parameter value is `12345abcde` (fictional, of course).
+
+After you request the lambda URL and the image resizing process finishes, you'll be redirected to the final image path:
+
+```
+http://<BUCKET>.s3-website.<REGION>.amazonaws.com/images_resized/1080x720/IMAGE_NAME.jpg
+```
+
+And this is the final public URL of the resized image, ready to be distributed in the new dimensions.
 
 Or you can access the lambda function directly.
-
-Example 2:
-```
-https://LAMBDA_ID.execute-api.REGION.amazonaws.com/dev/resize?key=420x360/IMAGE_NAME.jpg
-```
-
-This will resize the image on the fly and send you back the resized image while storing it for further reference.
 
 ## Credits
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -83,6 +83,8 @@ echo "------------------------"
 cd /deploy
 
 aws s3 cp --acl public-read ./static/ "s3://$bucket/static/" --recursive
+aws s3 cp --acl public-read ./images_original/ "s3://$bucket/images_original/" --recursive
+aws s3 cp --acl public-read ./images_resized/ "s3://$bucket/images_resized/" --recursive
 aws s3 cp --acl public-read index.html "s3://$bucket/"
 aws s3 cp --acl public-read error.html "s3://$bucket/"
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,6 +5,6 @@
   "main": "resize.js",
   "dependencies": {
     "serverless-plugin-tracing": "^2.0.0",
-    "sharp": "^0.26.3"
+    "sharp": "^0.30.7"
   }
 }

--- a/functions/serverless.yml
+++ b/functions/serverless.yml
@@ -5,7 +5,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   stage: ${env:STAGE, 'dev'}
   profile: ${env:PROFILE, 'default'}
   tracing:

--- a/images_original/.gitkeep
+++ b/images_original/.gitkeep
@@ -1,0 +1,1 @@
+# The original image files (yet to be resized) will be stored here

--- a/images_resized/.gitkeep
+++ b/images_resized/.gitkeep
@@ -1,0 +1,1 @@
+# The already resized image files (categorized by size) will be stored here


### PR DESCRIPTION
Bumped `nodejs12` to `nodejs16` as AWS is ending support for Node.js 12 in AWS Lambda. This follows Node.js 12 End-Of-Life (EOL) reached on [April 30, 2022](https://nodejs.org/en/blog/release/v12.22.12/).

Changed folder path structure inside the bucket to clarify original vs resized images (while still keeping the bucket's root as clean as possible).

Some minor improvements in the `README.md` file where also included.